### PR TITLE
Upgrades to logstash 2.3.1, and resolves manticore connectivity issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ Gemfile.lock
 vendor
 .idea
 *~
+logstash/

--- a/logstash-output-json_batch.gemspec
+++ b/logstash-output-json_batch.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-json_batch'
-  s.version         = '0.1.2'
+  s.version         = '0.2.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "This output lets you `POST` messages as JSON in a batched fashions"
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   # Files
-  s.files = Dir['lib/**/*','spec/**/*','vendor/**/*','*.gemspec','*.md','CONTRIBUTORS','Gemfile','LICENSE','NOTICE.TXT']
+  s.files = Dir['lib/**/*','spec/**/*','*.gemspec','*.md','Gemfile','LICENSE' ]
 
   # Tests
   s.test_files = s.files.grep(%r{^(test|spec|features)/})
@@ -19,12 +19,8 @@ Gem::Specification.new do |s|
   s.metadata = { "logstash_plugin" => "true", "logstash_group" => "output" }
 
   # Gem dependencies
-  s.add_runtime_dependency "logstash-core", ">= 2.1.0", "< 3.0.0"
-  s.add_runtime_dependency "logstash-mixin-http_client", ">= 2.0.2", "< 3.0.0"
-
-  # Constrain Maticore dependency to less than 0.5.0 because of changes in the async handling
-  # see note in http.rb line 92-93
-  s.add_runtime_dependency "manticore", "< 0.5.0"
+  s.add_runtime_dependency "logstash-core-plugin-api", "~> 1.0"
+  s.add_runtime_dependency "logstash-mixin-http_client", ">= 2.2.1", "< 3.0.0"
 
   s.add_development_dependency 'logstash-devutils'
   s.add_development_dependency 'sinatra'


### PR DESCRIPTION
Pulls in changes from logstash-output-http and updated to work with logstash 2.3.1. 

Stress tested to 1bn events without the time out problems described in #1. Does not resolve that issue though, as those configuration options are still not available to users of this plugin.
